### PR TITLE
(hotfix) Align nextjs output with expected Github Actions config

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -4,6 +4,7 @@ const nextConfig = {
     images: {
         unoptimized: true,  // <=== disables image optimization for static exports
     },
+    distDir: 'out',
 };
 
 export default nextConfig;


### PR DESCRIPTION
Changes:

  - Adds destDir to next.config.mjs to define output to `out`